### PR TITLE
fix threaded random projection indexer

### DIFF
--- a/src/main/org/fastlsh/util/BlockingThreadPool.java
+++ b/src/main/org/fastlsh/util/BlockingThreadPool.java
@@ -73,6 +73,7 @@ public class BlockingThreadPool
         
     public void awaitTermination(long timeout, TimeUnit unit) throws InterruptedException
     {        
-        pool.awaitTermination(timeout, unit);
+    	pool.shutdown();
+    	pool.awaitTermination(timeout, unit);
     }
 }


### PR DESCRIPTION
@mmastroianni can you check this?
- open writer resource pool before use
- return resource pool instead of null
- don't close pool before trying to acquire from it
- fix removing in-use writers
- tell thread pool to shut down before waiting for it to shutdown
